### PR TITLE
User status

### DIFF
--- a/app/facades/user_dashboard_facade.rb
+++ b/app/facades/user_dashboard_facade.rb
@@ -53,7 +53,7 @@ class UserDashboardFacade
   end
 
   def user_status
-    @user.email_confirmed? ? "Active" : "Inactive"
+    @user.email_confirmed? ? 'Active' : 'Inactive'
   end
 
   private

--- a/app/facades/user_dashboard_facade.rb
+++ b/app/facades/user_dashboard_facade.rb
@@ -52,6 +52,10 @@ class UserDashboardFacade
     @handles.include?(other_user.name)
   end
 
+  def user_status
+    @user.email_confirmed? ? "Active" : "Inactive"
+  end
+
   private
 
   attr_reader :user

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,6 +2,8 @@
 
   <h1> <%= current_user.first_name %>'s Dashboard </h1>
 
+  <p>Status: <%= facade.user_status %></p>
+
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>

--- a/spec/features/user/user_can_see_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_repos_on_dashboard_spec.rb
@@ -32,7 +32,7 @@ describe 'As a logged in user' do
 
         visit '/dashboard'
 
-        expect(page).to have_content("Status: Active")
+        expect(page).to have_content('Status: Active')
       end
     end
 
@@ -44,7 +44,7 @@ describe 'As a logged in user' do
 
         visit '/dashboard'
 
-        expect(page).to have_content("Status: Inactive")
+        expect(page).to have_content('Status: Inactive')
       end
     end
   end

--- a/spec/features/user/user_can_see_repos_on_dashboard_spec.rb
+++ b/spec/features/user/user_can_see_repos_on_dashboard_spec.rb
@@ -2,11 +2,6 @@
 
 require 'rails_helper'
 
-# As a logged in user
-# When I visit /dashboard
-# Then I should see a section for "Github"
-# And under that section I should see a list of 5 repositories with the name of each Repo linking to the repo on Github
-
 describe 'As a logged in user' do
   describe 'visiting their dashboard' do
     describe 'I see a section for github' do
@@ -26,6 +21,30 @@ describe 'As a logged in user' do
           expect(page).to have_content('GitHub')
           expect(page).to have_all_of_selectors('#repo-1', '#repo-2', '#repo-3', '#repo-4', '#repo-5')
         end
+      end
+    end
+
+    describe 'when I confirm my email' do
+      it 'I should see my status change to active' do
+        user1 = create(:user, email_confirmed: true)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+        visit '/dashboard'
+
+        expect(page).to have_content("Status: Active")
+      end
+    end
+
+    describe 'if I do not confirm my email' do
+      it 'I should see my status as inactive' do
+        user1 = create(:user, email_confirmed: false)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user1)
+
+        visit '/dashboard'
+
+        expect(page).to have_content("Status: Inactive")
       end
     end
   end

--- a/spec/features/user/users_get_an_activation_email_and_are_activated_spec.rb
+++ b/spec/features/user/users_get_an_activation_email_and_are_activated_spec.rb
@@ -11,6 +11,7 @@ describe 'As a registered user' do
 
     expect(current_path).to eq(welcome_path)
     expect(page).to have_content('Thank you! Your account is now activated.')
+    binding.pry
   end
 
   it 'I cant confirm unrecognized token', :vcr do

--- a/spec/features/user/users_get_an_activation_email_and_are_activated_spec.rb
+++ b/spec/features/user/users_get_an_activation_email_and_are_activated_spec.rb
@@ -11,7 +11,6 @@ describe 'As a registered user' do
 
     expect(current_path).to eq(welcome_path)
     expect(page).to have_content('Thank you! Your account is now activated.')
-    binding.pry
   end
 
   it 'I cant confirm unrecognized token', :vcr do


### PR DESCRIPTION
Adds feature test for user status active if email confirmed and inactive if email is not confirmed.
Adds method user_status to facade user dashboard.
All tests are passing.